### PR TITLE
added SERVERS and VOLNAME settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ host and everything is managed within the plugin.
 
 1 - Install the plugin
 ```
-docker plugin install mikebarkmin/glusterfs
+docker plugin install --alias glusterfs mikebarkmin/glusterfs
+
+# optional you can set a default server list and/or volume
+docker plugin install --alias glusterfs mikebarkmin/glusterfs SERVERS=<server1,server2,...,serverN> VOLNAME=<volname>
 
 # or to enable debug
-docker plugin install mikebarkmin/glusterfs DEBUG=1
+docker plugin install --alias glusterfs mikebarkmin/glusterfs DEBUG=1
 ```
 
 2 - Create a volume
@@ -24,11 +27,21 @@ docker plugin install mikebarkmin/glusterfs DEBUG=1
 > Or the mounting of the volume will fail.
 
 ```
-$ docker volume create -d mikebarkmin/glusterfs -o servers=<server1,server2,...,serverN> -o volname=<volname> -o subdir=<subdir> glustervolume
+$ docker volume create -d glusterfs -o servers=<server1,server2,...,serverN> -o volname=<volname> -o subdir=<subdir> glustervolume
 glustervolume
 $ docker volume ls
-DRIVER                       VOLUME NAME
-mikebarkmin/glusterfs:next   glustervolume
+DRIVER           VOLUME NAME
+glusterfs:next   glustervolume
+```
+
+or if you set the defaults for the plugin, you can create a volume without any options:
+
+```
+$ docker volume create -d glusterfs glustervolume
+glustervolume
+$ docker volume ls
+DRIVER           VOLUME NAME
+glusterfs:next   glustervolume
 ```
 
 3 - Use the volume
@@ -38,9 +51,9 @@ $ docker run -it -v glustervolume:<path> bash ls <path>
 
 ## Options
 
-* servers [required]: A comma-separated list of servers e.g.: 192.168.2.1,192.168.1.1
-* volname [required]: The name of the glusterfs volume e.g.: gv0. Needs to be defined on the glusterfs cluster.
-* subdir [required]: The name of the subdir. Will be created, if not found.
+* servers [required, if no default set]: A comma-separated list of servers e.g.: 192.168.2.1,192.168.1.1
+* volname [required, if no default set]: The name of the glusterfs volume e.g.: gv0. Needs to be defined on the glusterfs cluster.
+* subdir [optional, default: volume name]: The name of the subdir. Will be created, if not found.
 
 For additional options see [man mount.glusterfs](https://github.com/gluster/glusterfs/blob/release-6/doc/mount.glusterfs.8).
 

--- a/config.json
+++ b/config.json
@@ -7,6 +7,16 @@
       "name": "DEBUG",
       "settable": ["value"],
       "value": "0"
+    },
+    {
+      "name": "SERVERS",
+      "settable": ["value"],
+      "value": ""
+    },
+    {
+      "name": "VOLNAME",
+      "settable": ["value"],
+      "value": ""
     }
   ],
   "interface": {


### PR DESCRIPTION
The SERVERS and VOLNAME settings act as the default, when no matching option is set at volume creation. Also the volume name acts as the default for the subdir option. With these changes a new volume can be created without any required options.