### PR TITLE
Compact image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,12 @@ CMD ["/go/bin/docker-volume-glusterfs"]
 
 FROM ubuntu:20.04
 RUN apt-get update \
-  && apt-get install software-properties-common -y
-RUN add-apt-repository ppa:gluster/glusterfs-9 \ 
+  && apt-get install software-properties-common -y \
+  && add-apt-repository ppa:gluster/glusterfs-9 \
   && apt-get update \
   && apt-get install glusterfs-client -y \
+  && apt-get purge software-properties-common -y \
+  && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /go/bin/docker-volume-glusterfs .
 CMD ["docker-volume-glusterfs"]


### PR DESCRIPTION
In Raspberry Pi 4, image reduced 238MB to 181MB